### PR TITLE
add setTransactionManagerBeanName

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionProxyFactoryBean.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionProxyFactoryBean.java
@@ -128,6 +128,14 @@ public class TransactionProxyFactoryBean extends AbstractSingletonProxyFactoryBe
 	public void setTransactionManager(PlatformTransactionManager transactionManager) {
 		this.transactionInterceptor.setTransactionManager(transactionManager);
 	}
+	
+        /**
+	 * Specify the name of the default transaction manager bean.
+	 * @see TransactionAspectSupport#setTransactionManagerBeanName
+	 */
+	public void setTransactionManagerBeanName(String transactionManagerBeanName) {
+		this.transactionInterceptor.setTransactionManagerBeanName(transactionManagerBeanName);
+	}
 
 	/**
 	 * Set properties with method names as keys and transaction attribute


### PR DESCRIPTION
add setTransactionManagerBeanName for set TransactionAspectSupport#setTransactionManagerBeanName

so one beanfactory can have more than one TransactionManager 
otherwise will:
`
org.springframework.beans.factory.NoUniqueBeanDefinitionException: No qualifying bean of type [org.springframework.transaction.PlatformTransactionManager] is defined: expected single matching bean but found 2: transactionManagerLog,transactionManager
    at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBean(DefaultListableBeanFactory.java:368)
    at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBean(DefaultListableBeanFactory.java:371)
`
